### PR TITLE
[Dep] Using rector-generator dev-main

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "symplify/easy-coding-standard": "^10.0",
         "symplify/rule-doc-generator": "^10.0",
         "rector/rector-src": "dev-main",
-        "rector/rector-generator": "^0.4",
+        "rector/rector-generator": "dev-main",
         "phpstan/phpstan-strict-rules": "^1.1",
         "phpstan/phpstan-webmozart-assert": "^1.0",
         "symplify/vendor-patches": "^10.0",


### PR DESCRIPTION
To sync up with other rector-* packages that require dev-main, also part of solving https://github.com/rectorphp/rector-src/pull/1453#issuecomment-991517813 that temporary tweaked at https://github.com/rectorphp/rector-src/pull/1458