### PR TITLE
[PhpOffice] Add RemoveExtraParametersRector to phpexcel-to-phpspreadsheet set

### DIFF
--- a/config/sets/phpexcel-to-phpspreadsheet.php
+++ b/config/sets/phpexcel-to-phpspreadsheet.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Rector\Php71\Rector\FuncCall\RemoveExtraParametersRector;
 use Rector\PHPOffice\Rector\MethodCall\ChangeConditionalGetConditionRector;
 use Rector\PHPOffice\Rector\MethodCall\ChangeConditionalReturnedCellRector;
 use Rector\PHPOffice\Rector\MethodCall\ChangeConditionalSetConditionRector;
@@ -305,4 +306,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             'PHPExcel_Style' => 'PhpOffice\PhpSpreadsheet\Style\Style',
             'PHPExcel_Worksheet' => 'PhpOffice\PhpSpreadsheet\Worksheet\Worksheet',
         ]);
+    $services->set(RemoveExtraParametersRector::class);
 };

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -23,3 +23,5 @@ parameters:
 
         # rector co-variant
         - '#Parameter \#1 \$node \(PhpParser\\Node\\(.*?) of method Rector\\(.*?)\(\) should be contravariant with parameter \$node \(PhpParser\\Node\) of method Rector\\Core\\Contract\\Rector\\PhpRectorInterface\:\:refactor\(\)#'
+
+        - '#Add explicit array type to assigned "\$node\->args" expression#'


### PR DESCRIPTION
The config set may be used for multiple phpspreadsheet version, eg, on 1.17.1, on `getColumnDimension()`, 3rd arg is needed

https://github.com/PHPOffice/PhpSpreadsheet/blob/c55269cb06911575a126dc225a05c0e4626e5fb4/src/PhpSpreadsheet/Worksheet/Worksheet.php#L1227

while in 1.22.0, its not needed

https://github.com/PHPOffice/PhpSpreadsheet/blob/3a9e29b4f386a08a151a33578e80ef1747037a48/src/PhpSpreadsheet/Worksheet/Worksheet.php#L1271

Fixes https://github.com/rectorphp/rector/issues/7072